### PR TITLE
fix: unconverted data remains error

### DIFF
--- a/custom_components/covid19_kr/__init__.py
+++ b/custom_components/covid19_kr/__init__.py
@@ -87,8 +87,8 @@ async def get_coordinator(hass: HomeAssistant, entry: ConfigEntry) -> DataUpdate
             data.update({
                 "attribute": { s: (lambda x: { attribute[x][0][n]: selector(attribute[x][1][n]) for n in range(len(attribute[x][0])) })(s) for s in attribute },
                 "last_update": datetime.strptime(
-                    (str(datetime.now().year) if _sido in ["전국", "부산", "울산"] else "") +
-                    ''.join(str(format(int(x), '02' if i or _sido in ["부산", "울산", "경북"] else '04')) for i, x in enumerate(re.split('[^0-9]', cr.select_one(SIDO_LIST[_sido]['last_update']).text)) if x), 
+                    (str(datetime.now().year) if _sido in ["부산", "울산"] else "") +
+                    ''.join(str(format(int(x), '02' if i or _sido in ["부산", "울산", "경북"] else '04')) for i, x in enumerate(re.split('[^0-9]', cr.select_one(SIDO_LIST[_sido]['last_update']).text)) if x),
                     "%Y%m%d%H" + ("%M" if _sido in ["인천", "경기", "경북"] else "")
                 ).astimezone().replace(microsecond=0).isoformat()
             })


### PR DESCRIPTION
전국으로 설정했을 때 datetime 값으로 연도가 중복돼서 예외가 발생하네요.

전국 예외 처리가 없었다가 생긴 걸 보니 나중에 다시 예외 적용해야 할 수도 있을 것 같아서
근본적으로 해결하고 싶은데 파이썬에 익숙하지 않아서...
급한대로 제가 사용하려고 단순하게 수정한걸로 일단 PR 올려봐요


```
Logger: custom_components.covid19_kr
Source: custom_components/covid19_kr/__init__.py:89
Integration: 코로나 현황 ([documentation](https://github.com/huimang2/covid19_kr))
First occurred: 14:43:42 (74 occurrences)
Last logged: 16:16:52

Unexpected error fetching covid19_kr data: unconverted data remains: 21200
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 187, in _async_refresh
    self.data = await self._async_update_data()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 147, in _async_update_data
    return await self.update_method()
  File "/config/custom_components/covid19_kr/__init__.py", line 89, in async_get_data
    "last_update": datetime.strptime(
  File "/usr/local/lib/python3.9/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.9/_strptime.py", line 352, in _strptime
    raise ValueError("unconverted data remains: %s" %
ValueError: unconverted data remains: 21200
```
















